### PR TITLE
fix: adjust error response type

### DIFF
--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -1,7 +1,19 @@
+type FieldError = {
+  code: string;
+  message: string;
+  property: string;
+};
+
+type GlobalError = {
+  code: string;
+  message: string;
+};
+
 type Error = {
-  error?: string;
-  message?: string;
-  errors?: Record<string, string>[];
+  code: string;
+  message: string;
+  fieldErrors?: FieldError[];
+  globalErrors?: GlobalError[];
 };
 
 type LeanResponse = Pick<

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -1,19 +1,15 @@
-type FieldError = {
+type BaseError = {
   code: string;
   message: string;
-  property: string;
 };
 
-type GlobalError = {
-  code: string;
-  message: string;
-};
+type FieldError = BaseError & { property: string };
 
 type Error = {
   code: string;
   message: string;
   fieldErrors?: FieldError[];
-  globalErrors?: GlobalError[];
+  globalErrors?: BaseError[];
 };
 
 type LeanResponse = Pick<


### PR DESCRIPTION
Adjusts the `Error` type to follow the error response format delivered by the BE:

```json
{
   "code": "VALIDATION_FAILED",
   "message": "Validation failed for object='buyerAnonymiseDto'. Error count: 2",
   "fieldErrors": [{
      "code": "REQUIRED_NOT_BLANK",
      "message": "must not be blank",
      "property": "salt",
      "rejectedValue": null,
      "path": "salt"
   }],
   "globalErrors": [{
      "code": "EMAIL_OR_PHONE_NOT_BLANK",
      "message": "email or phone must be provided"
   }]
}
```

It will be a BREAKING CHANGE due to the change in the error data-type