### PR TITLE
fix: add typing property in field errors

### DIFF
--- a/.jest/helpers/listingClient.ts
+++ b/.jest/helpers/listingClient.ts
@@ -11,23 +11,23 @@ export type Listing = {
 
 export interface ListingClientConfiguration extends ClientConfiguration {
   'dealers/{dealerId}/listings/{dealerId}': {
-    get: () => ResponseType<Listing>;
+    get: () => ResponseType<never, Listing>;
   };
   '/listings/search': {
-    get: (data?: RequestType) => ResponseType<Listing>;
+    get: (data?: RequestType) => ResponseType<never, Listing>;
   };
   '/listings/{listingId}': {
     delete: () => ResponseType;
-    put: (data: RequestType<Listing>) => ResponseType;
+    put: (data: RequestType<Listing>) => ResponseType<Listing>;
   };
   'dealers/{dealerId}/listings/{listingId}': {
     delete: () => ResponseType;
   };
   '/listings/create': {
-    post: (data: RequestType<Listing>) => ResponseType;
+    post: (data: RequestType<Listing>) => ResponseType<Listing>;
   };
   '/calculate': {
-    post: (data: RequestType<null>) => ResponseType;
+    post: (data: RequestType<null>) => ResponseType<Listing>;
   };
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,10 +10,10 @@ export type RequestType<T = never> = {
 };
 
 type Methods = {
-  get?: (request: RequestType) => ResponseType<any>;
-  post?: (request: RequestType<any>) => ResponseType<any>;
-  put?: (request: RequestType<any>) => ResponseType<any>;
-  delete?: (request: RequestType) => ResponseType<any>;
+  get?: (request: RequestType) => ResponseType<never, any>;
+  post?: (request: RequestType<any>) => ResponseType<any, any>;
+  put?: (request: RequestType<any>) => ResponseType<any, any>;
+  delete?: (request: RequestType) => ResponseType<never, any>;
 };
 
 export type ClientConfiguration = Record<string, Methods>;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,10 +4,10 @@ import { ResponseType } from './responseType';
 
 import { RequestOptions } from './index';
 
-export interface RequestType<T = never> {
+export type RequestType<T = never> = {
   options?: RequestOptions;
   data?: T;
-}
+};
 
 type Methods = {
   get?: (request: RequestType) => ResponseType<any>;

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -45,7 +45,9 @@ export class FetchClient {
     };
   }
 
-  private static async returnData<T>(response: Response): ResponseType<T> {
+  private static async returnData<T>(
+    response: Response
+  ): ResponseType<unknown, T> {
     const text = await response.text();
     const data = text.length > 0 ? JSON.parse(text) : {};
     const { headers, ok, redirected, status, statusText, type, url } = response;

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -3,12 +3,10 @@ type BaseError = {
   message: string;
 };
 
-type FieldError = BaseError & { property: string };
+type FieldError<RequestData> = BaseError & { property: keyof RequestData };
 
-type Error = {
-  code: string;
-  message: string;
-  fieldErrors?: FieldError[];
+type Error<RequestData> = BaseError & {
+  fieldErrors?: FieldError<RequestData>[];
   globalErrors?: BaseError[];
 };
 
@@ -17,9 +15,9 @@ type LeanResponse = Pick<
   'headers' | 'ok' | 'redirected' | 'status' | 'statusText' | 'type' | 'url'
 >;
 
-interface ErrorResponse extends LeanResponse {
+interface ErrorResponse<RequestData> extends LeanResponse {
   ok: false;
-  body: Error;
+  body: Error<RequestData>;
 }
 
 interface SuccessResponse<Body> extends LeanResponse {
@@ -27,6 +25,6 @@ interface SuccessResponse<Body> extends LeanResponse {
   body: Body;
 }
 
-export type ResponseType<Body = never> = Promise<
-  ErrorResponse | SuccessResponse<Body>
+export type ResponseType<Body = never, RequestData = never> = Promise<
+  ErrorResponse<RequestData> | SuccessResponse<Body>
 >;

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -25,6 +25,7 @@ interface SuccessResponse<Body> extends LeanResponse {
   body: Body;
 }
 
-export type ResponseType<RequestData = unknown, Body = never> = Promise<
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ResponseType<RequestData = any, Body = never> = Promise<
   ErrorResponse<RequestData> | SuccessResponse<Body>
 >;

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -25,6 +25,6 @@ interface SuccessResponse<Body> extends LeanResponse {
   body: Body;
 }
 
-export type ResponseType<Body = never, RequestData = never> = Promise<
+export type ResponseType<RequestData = unknown, Body = never> = Promise<
   ErrorResponse<RequestData> | SuccessResponse<Body>
 >;


### PR DESCRIPTION
Adds typing to the `fieldError` property on the error response so that it's easier to use with libraries like formik.