### PR TITLE
Lint hidden folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+!/.jest
+!.prettierrc.js

--- a/.jest/helpers/fetch.ts
+++ b/.jest/helpers/fetch.ts
@@ -1,6 +1,6 @@
 import { fetchMock } from '../setup/fetchMock';
 
-export const mockResolvedOnce = (value: any) => {
+export const mockResolvedOnce = (value: unknown) => {
   fetchMock.mockReturnValueOnce(
     Promise.resolve({
       status: 200,

--- a/.jest/helpers/listingClient.ts
+++ b/.jest/helpers/listingClient.ts
@@ -1,8 +1,8 @@
 import {
-  ResponseType,
   ApiClient,
   ClientConfiguration,
   RequestType,
+  ResponseType,
 } from '../../src';
 
 export type Listing = {

--- a/.jest/setup/fetchMock.ts
+++ b/.jest/setup/fetchMock.ts
@@ -1,4 +1,4 @@
-const fetchMock = jest.fn()
-global.fetch = fetchMock
+const fetchMock = jest.fn();
+global.fetch = fetchMock;
 
-export { fetchMock }
+export { fetchMock };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  ...require("@smg-automotive/eslint-config/prettier"),
-}
+  ...require('@smg-automotive/eslint-config/prettier'),
+};


### PR DESCRIPTION
[FE-61](https://autoricardo.atlassian.net/browse/FE-61?atlOrigin=eyJpIjoiZDJlOGQ3YmYxOGI4NDMyODk5Y2E5OWFkYTY0Yzc3MjkiLCJwIjoiaiJ9)

## Motivation and context

By default, hidden folders are not linted by eslint, we need to add them to the eslint ignore file with a !. 
I tried to come up with something global that could be done at the eslint pkg level but could not find anything. 

## Before

.jest folder was not linted

## After

.jest folder is linter
