### PR TITLE
fix: export success and error response type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ResponseType } from './responseType';
+import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
 import { replaceParameters } from './pathParameters';
 import { Path } from './path';
 import {
@@ -55,6 +55,8 @@ export {
   ClientConfiguration,
   ResponseType,
   RequestType,
+  SuccessResponse,
+  ErrorResponse,
   PaginatedQuery,
   PaginatedResponse,
   PaginationQuery,

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -19,12 +19,13 @@ type LeanResponse = Pick<
   'headers' | 'ok' | 'redirected' | 'status' | 'statusText' | 'type' | 'url'
 >;
 
-interface ErrorResponse<RequestData extends object> extends LeanResponse {
+export interface ErrorResponse<RequestData extends object>
+  extends LeanResponse {
   ok: false;
   body: Error<RequestData>;
 }
 
-interface SuccessResponse<Body> extends LeanResponse {
+export interface SuccessResponse<Body> extends LeanResponse {
   ok: true;
   body: Body;
 }


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Exporting `SuccessResponse` and `ErrorResponse` in order to use them outside of package.

## Before

N/A

## After

`SuccessResponse` and `ErrorResponse` exported

## How to test

[Add a deep link and instructions how to verify the new behavior]
