### PR TITLE
feat: export SortOrderParams enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SortedQuery, SortParams, SortQuery } from './sort';
+import { SortedQuery, SortParams, SortQuery, SortOrderParams } from './sort';
 import { Sanitizers } from './sanitizers';
 import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
 import { replaceParameters } from './pathParameters';
@@ -97,4 +97,5 @@ export {
   SortQuery,
   SortParams,
   SortedQuery,
+  SortOrderParams
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SortedQuery, SortParams, SortQuery, SortOrderParams } from './sort';
+import { SortedQuery, SortOrderParams, SortParams, SortQuery } from './sort';
 import { Sanitizers } from './sanitizers';
 import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
 import { replaceParameters } from './pathParameters';
@@ -95,7 +95,7 @@ export {
   PaginatedResponse,
   PaginationQuery,
   SortQuery,
+  SortOrderParams,
   SortParams,
   SortedQuery,
-  SortOrderParams
 };


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

We missed to export this type. It provides ASC and DESC order

