### PR TITLE
chore: imporve error message when non JSON is returned form the API

### DIFF
--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -1,5 +1,5 @@
 import { DataSanitizer } from './sanitizers';
-import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
+import { ResponseType } from './responseType';
 
 import { FetchClientConfiguration, RequestOptions } from './index';
 


### PR DESCRIPTION
References https://autoricardo.atlassian.net/browse/IN-1228

## Motivation and context

Last Friday the page was offline and we got some `Unexpected token < in JSON at position 0` errors. After a fair bit of analysing, I realized we are getting gateway timeouts as HTML responses form Cloudflare.

The app is likely not to work at all if we cannot get data, therefore I decided to re-throw the error but with a more meaningful message and some additional information to streamline future analysis on the error source