### PR TITLE
chore: remove disabled eslint rules for naming convention

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -57,9 +57,7 @@ describe('ApiClient', () => {
       options: {
         baseUrl: 'https://petstoreapi.ch',
         headers: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           'Content-Type': 'text/xml',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           'Accept-Language': 'fr-CH',
         },
       },
@@ -67,7 +65,6 @@ describe('ApiClient', () => {
     expect(fetch).toHaveBeenCalledWith(
       'https://petstoreapi.ch/listings/search',
       expect.objectContaining({
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         headers: { 'Content-Type': 'text/xml', 'Accept-Language': 'fr-CH' },
       }),
     );
@@ -78,14 +75,12 @@ describe('ApiClient', () => {
     const client = ApiClient<ListingClientConfiguration>({
       baseUrl: 'https://api.automotive.ch/api',
       headers: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         'Accept-Language': 'fr-CH',
       },
     });
     await client.path('/listings/search').get({
       options: {
         headers: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           'Content-Type': 'text/xml',
         },
       },
@@ -93,7 +88,6 @@ describe('ApiClient', () => {
     expect(fetch).toHaveBeenCalledWith(
       'https://api.automotive.ch/api/listings/search',
       expect.objectContaining({
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         headers: { 'Content-Type': 'text/xml', 'Accept-Language': 'fr-CH' },
       }),
     );

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -6,7 +6,6 @@ import { FetchClientConfiguration, RequestOptions } from './index';
 export class FetchClient {
   private readonly configuration: FetchClientConfiguration = {
     baseUrl: '',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     headers: { 'Content-Type': 'application/json' },
   };
 


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/IN-1714

## Motivation and context

Some ESLint configurations were set as global configs and respective lines for disabling them can be removed from the project.

## Before

ESLint lines for disabling uppercase property names and double leading underscore exist.

## After

ESLint lines for disabling uppercase property names and double leading underscore don't exist.

