### PR TITLE
feat: forwarding query param in path

### DIFF
--- a/.jest/helpers/listingClient.ts
+++ b/.jest/helpers/listingClient.ts
@@ -4,6 +4,10 @@ export type Listing = {
   make: string;
 };
 
+export type Seller = {
+  name: string;
+};
+
 interface DummySearchParams {
   test: string;
 }
@@ -52,4 +56,16 @@ export const listingClient = ApiClient<ListingClientConfiguration>({
       delete: sanitizeListing,
     },
   },
+});
+
+interface SellersSearchClientConfiguration extends ClientConfiguration {
+  '/sellers/search': {
+    post: (
+      data: RequestType<Seller, DummySearchParams>,
+    ) => ResponseType<object, Seller>;
+  };
+}
+
+export const sellersSearchClient = ApiClient<SellersSearchClientConfiguration>({
+  baseUrl: 'https://api.automotive.ch/api',
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import {
   listingClient,
   ListingClientConfiguration,
+  sellersSearchClient,
 } from '.jest/helpers/listingClient';
 import { mockFetchFailOnce, mockResolvedOnce } from '.jest/helpers/fetch';
 
@@ -158,7 +159,7 @@ describe('ApiClient', () => {
     );
   });
 
-  it('adds searchParams', async () => {
+  it('adds searchParams on method GET', async () => {
     mockResolvedOnce({ data: '12345' });
     await listingClient.path('/listings/search').get({
       options: {
@@ -168,6 +169,20 @@ describe('ApiClient', () => {
     });
     expect(fetch).toHaveBeenCalledWith(
       'https://petstoreapi.ch/listings/search?test=hereIAm',
+      expect.any(Object),
+    );
+  });
+
+  it('adds searchParams on method POST', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await sellersSearchClient.path('/sellers/search').post({
+      options: {
+        baseUrl: 'https://petstoreapi.ch/',
+      },
+      searchParams: { test: 'hereIAm' },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://petstoreapi.ch/sellers/search?test=hereIAm',
       expect.any(Object),
     );
   });

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -166,12 +166,14 @@ export class FetchClient {
     path,
     body: originalBody,
     options,
+    searchParams,
     sanitizer,
   }: {
     path: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     body: any;
     options?: RequestOptions;
+    searchParams?: Record<string, string>;
     sanitizer?: DataSanitizer<T>;
   }): ResponseType<object, T> => {
     const headers = this.getHeaders(options);
@@ -184,7 +186,7 @@ export class FetchClient {
     }
 
     return FetchClient.returnData(
-      await fetch(this.getPath({ path, options }), {
+      await fetch(this.getPath({ path, options, searchParams }), {
         method: 'POST',
         headers,
         body,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,12 @@ function StronglyTypedClient<Configuration extends ClientConfiguration>(
             sanitizer: pathSanitizers?.get,
           });
         },
-        post: ({ data, options } = { data: {}, options: {} }) => {
+        post: ({ data, options, searchParams } = { data: {}, options: {} }) => {
           return fetchClient.post({
             path: replacedPath,
             body: data,
             options,
+            searchParams,
             sanitizer: pathSanitizers?.post,
           });
         },


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3328
Swagger -> https://internal.dev.autoscout24.ch/api-docs/swagger-ui/?urls.primaryName=listing-search-service#/Seller%20Search/search_1

## Motivation and context

we need the query param in the post method. Therefore, we need to extend our api-client-pkg to be able to follow our convention.

## How to test
This adjustment is applied in the listings-web project for showing the corresponding content depending the brand which is passed as a query parameter -> https://github.com/smg-automotive/listings-web/pull/2385

## Thank you 🧝🏽‍♀️ 🩵 🐈
