### PR TITLE
feat: handle json parse errors

### DIFF
--- a/.jest/helpers/fetch.ts
+++ b/.jest/helpers/fetch.ts
@@ -32,3 +32,18 @@ export const mockApiFailOnce = () => {
     }),
   );
 };
+
+export const mockUnexpectedHTMLOnce = () => {
+  fetchMock.mockImplementationOnce((url) =>
+    Promise.resolve({
+      url,
+      ok: true,
+      status: 200,
+      text: () => {
+        return Promise.resolve(
+          '<html><body>You have been blocked</body></html>',
+        );
+      },
+    }),
+  );
+};

--- a/src/__tests__/delete.test.ts
+++ b/src/__tests__/delete.test.ts
@@ -1,5 +1,5 @@
 import { listingClient } from '.jest/helpers/listingClient';
-import { mockResolvedOnce } from '.jest/helpers/fetch';
+import { mockResolvedOnce, mockUnexpectedHTMLOnce } from '.jest/helpers/fetch';
 
 describe('delete', () => {
   it('calls fetch with DELETE', async () => {
@@ -20,5 +20,28 @@ describe('delete', () => {
       .delete();
 
     expect(response.body).toEqual({ make: 'default make' });
+  });
+
+  it('handles JSON parsing errors', async () => {
+    expect.assertions(2);
+
+    mockUnexpectedHTMLOnce();
+    const response = await listingClient
+      .path('/listings/{listingId}/unsanitized', { listingId: 1 })
+      .delete();
+
+    if (!response.ok) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.message).toEqual(
+        'Failed to parse JSON response from https://api.automotive.ch/api/listings/1/unsanitized',
+      );
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.globalErrors).toContainEqual(
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect.objectContaining({
+          code: 'JSON_PARSE_ERROR',
+        }),
+      );
+    }
   });
 });

--- a/src/__tests__/get.test.ts
+++ b/src/__tests__/get.test.ts
@@ -1,5 +1,9 @@
 import { Listing, listingClient } from '.jest/helpers/listingClient';
-import { mockApiFailOnce, mockResolvedOnce } from '.jest/helpers/fetch';
+import {
+  mockApiFailOnce,
+  mockResolvedOnce,
+  mockUnexpectedHTMLOnce,
+} from '.jest/helpers/fetch';
 
 describe('get', () => {
   it('calls fetch with GET', async () => {
@@ -27,11 +31,34 @@ describe('get', () => {
   });
 
   it('has an error object if the request was not ok', async () => {
+    expect.assertions(1);
+
     mockApiFailOnce();
     const data = await listingClient.path('/listings/search').get();
     if (!data.ok) {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(data?.body?.message).toEqual('Wrong data format');
+    }
+  });
+
+  it('handles JSON parsing errors', async () => {
+    expect.assertions(2);
+
+    mockUnexpectedHTMLOnce();
+    const response = await listingClient.path('/listings/search').get();
+
+    if (!response.ok) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.message).toEqual(
+        'Failed to parse JSON response from https://api.automotive.ch/api/listings/search',
+      );
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.globalErrors).toContainEqual(
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect.objectContaining({
+          code: 'JSON_PARSE_ERROR',
+        }),
+      );
     }
   });
 });

--- a/src/__tests__/post.test.ts
+++ b/src/__tests__/post.test.ts
@@ -1,5 +1,5 @@
 import { listingClient } from '.jest/helpers/listingClient';
-import { mockResolvedOnce } from '.jest/helpers/fetch';
+import { mockResolvedOnce, mockUnexpectedHTMLOnce } from '.jest/helpers/fetch';
 
 describe('post', () => {
   it('calls fetch with POST', async () => {
@@ -29,5 +29,28 @@ describe('post', () => {
       .post({});
 
     expect(response.body).toEqual({ make: 'default make' });
+  });
+
+  it('handles JSON parsing errors', async () => {
+    expect.assertions(2);
+
+    mockUnexpectedHTMLOnce();
+    const response = await listingClient
+      .path('/listings/{listingId}/unsanitized', { listingId: 1 })
+      .post({});
+
+    if (!response.ok) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.message).toEqual(
+        'Failed to parse JSON response from https://api.automotive.ch/api/listings/1/unsanitized',
+      );
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.globalErrors).toContainEqual(
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect.objectContaining({
+          code: 'JSON_PARSE_ERROR',
+        }),
+      );
+    }
   });
 });

--- a/src/__tests__/put.test.ts
+++ b/src/__tests__/put.test.ts
@@ -1,5 +1,5 @@
 import { listingClient } from '.jest/helpers/listingClient';
-import { mockResolvedOnce } from '.jest/helpers/fetch';
+import { mockResolvedOnce, mockUnexpectedHTMLOnce } from '.jest/helpers/fetch';
 
 describe('put', () => {
   it('calls fetch with PUT', async () => {
@@ -22,5 +22,28 @@ describe('put', () => {
       .put({});
 
     expect(response.body).toEqual({ make: 'default make' });
+  });
+
+  it('handles JSON parsing errors', async () => {
+    expect.assertions(2);
+
+    mockUnexpectedHTMLOnce();
+    const response = await listingClient
+      .path('/listings/{listingId}/unsanitized', { listingId: 1 })
+      .put({});
+
+    if (!response.ok) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.message).toEqual(
+        'Failed to parse JSON response from https://api.automotive.ch/api/listings/1/unsanitized',
+      );
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(response.body.globalErrors).toContainEqual(
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect.objectContaining({
+          code: 'JSON_PARSE_ERROR',
+        }),
+      );
+    }
   });
 });

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -35,9 +35,7 @@ export class FetchClient {
     ].join('/');
 
     const urlSearchParams = new URLSearchParams(searchParams).toString();
-    const queryString = `${urlSearchParams ? '?' : ''}${
-      urlSearchParams ? urlSearchParams : ''
-    }`;
+    const queryString = urlSearchParams ? `?${urlSearchParams}` : '';
 
     return `${normalizedPath}${queryString}`;
   }

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -101,22 +101,22 @@ export class FetchClient {
         sanitizer ? sanitizer(parsedBody) : parsedBody,
       );
     } catch (error) {
-      const { status, statusText, url } = response;
+      const { url } = response;
 
       // Custom HTML error
       if (
         error instanceof Error &&
-        error.message.trim() === 'Unexpected token < in JSON at position 0'
+        error.message.trim().match(/Unexpected token .* JSON/)
       ) {
-        throw new Error(
-          `Could not parse the response of the following request ${JSON.stringify(
+        return FetchClient.buildResponseDataObject({ ...response, ok: false }, {
+          message: `Failed to parse JSON response from ${url}`,
+          globalErrors: [
             {
-              url,
-              status,
-              statusText,
+              code: 'JSON_PARSE_ERROR',
+              message: error.message,
             },
-          )}`,
-        );
+          ],
+        } as ResponseData);
       }
 
       throw error;

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -119,23 +119,6 @@ export class FetchClient {
         );
       }
 
-      // Custom unexpected token 'I' error
-      if (
-        error instanceof Error &&
-        error.message.trim().startsWith("Unexpected token 'I'")
-      ) {
-        throw new Error(
-          `Could not parse the response of the following request ${JSON.stringify(
-            {
-              url,
-              status,
-              statusText,
-              text,
-            },
-          )}`,
-        );
-      }
-
       throw error;
     }
   }


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/FED-99

## Motivation and context

API client would throw an error when parsing JSON response failed. This overloaded our monitors and prevented applications from handling that failure gracefully.

This PR changes that and:
- drops custom handing of incomplete api tokens (properly handled by the BE now)
- do not raise an error when JSON parsing fails anymore. Instead, an unsuccessful response with `JSON_PARSE_ERROR` global error code is returned

