### PR TITLE
fix: adding keepalive option to post requests

### DIFF
--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -188,6 +188,7 @@ export class FetchClient {
         method: 'POST',
         headers,
         body,
+        ...(options?.keepalive && { keepalive: true }),
       }),
       sanitizer,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export interface RequestOptions {
   baseUrl?: string;
   headers?: Record<string, string>;
   accessToken?: string;
+  keepalive?: boolean;
 }
 
 function StronglyTypedClient<Configuration extends ClientConfiguration>(


### PR DESCRIPTION
References [link the ticket here]

## Motivation and context

Adding the `keepalive` option ensures that HTTP requests with `keepalive: true` are completed even if the page initiating the request is unloaded before the request finishes. This is particularly useful for sending tracking data when users navigate away via external links.

https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive

## Before

[Describe the current behavior and / or add a screenshot of the current state]

## After

[Describe the new behavior and / or add a screenshot of the new state]

## How to test

[Add a deep link and instructions how to verify the new behavior]
