### PR TITLE
fix: accept null as a valid  access token option

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -110,6 +110,24 @@ describe('ApiClient', () => {
     );
   });
 
+  it('does not create an authorization header if null is passed as access token', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient.path('/listings/search').get({
+      options: {
+        baseUrl: 'https://petstoreapi.ch',
+        accessToken: null,
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://petstoreapi.ch/listings/search',
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
+        }),
+      }),
+    );
+  });
+
   it('throws if no parameters are passed', async () => {
     await expect(async () => {
       await listingClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ interface ApiClientConfiguration<Configuration extends ClientConfiguration>
 export interface RequestOptions {
   baseUrl?: string;
   headers?: Record<string, string>;
-  accessToken?: string;
+  accessToken?: string | null;
 }
 
 function StronglyTypedClient<Configuration extends ClientConfiguration>(


### PR DESCRIPTION
References auth0 release

## Motivation and context

With the release of the auth0 integration, we changed the auth context interface and explicitly return `null` if the user is not authenticated. This resulted in some friction in the usage and a need for explicit `null` checking. This PR extend the request options type to accept the `null` as an access token. The behaviour stays the same - we only add the authorisation header when we pass a valid access token option. 

