### PR TITLE
feat: pass through options to extended fetch

### DIFF
--- a/.jest/helpers/listingClient.ts
+++ b/.jest/helpers/listingClient.ts
@@ -22,7 +22,7 @@ export interface ListingClientConfiguration extends ClientConfiguration {
     ) => ResponseType<never, Listing>;
   };
   '/listings/{listingId}': {
-    delete: () => ResponseType;
+    delete: (data?: RequestType<never>) => ResponseType;
     put: (data: RequestType<Listing>) => ResponseType<Listing>;
   };
   'dealers/{dealerId}/listings/{listingId}': {

--- a/src/__tests__/delete.test.ts
+++ b/src/__tests__/delete.test.ts
@@ -13,6 +13,40 @@ describe('delete', () => {
     );
   });
 
+  it('passes the cache options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient
+      .path('/listings/{listingId}', { listingId: 123 })
+      .delete({
+        options: {
+          cache: 'no-store',
+        },
+      });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/123',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('passes the next options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient
+      .path('/listings/{listingId}', { listingId: 123 })
+      .delete({
+        options: {
+          next: {
+            revalidate: 10,
+            tags: ['listings'],
+          },
+        },
+      });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/123',
+      expect.objectContaining({ next: { revalidate: 10, tags: ['listings'] } }),
+    );
+  });
+
   it('applies a sanitizer', async () => {
     mockResolvedOnce({});
     const response = await listingClient

--- a/src/__tests__/get.test.ts
+++ b/src/__tests__/get.test.ts
@@ -15,6 +15,36 @@ describe('get', () => {
     );
   });
 
+  it('passes the cache options to fetch', async () => {
+    mockResolvedOnce({ make: 'bmw' });
+    await listingClient.path('/listings/search').get({
+      options: {
+        cache: 'no-store',
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/search',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('passes the next options to fetch', async () => {
+    mockResolvedOnce({ make: 'bmw' });
+    await listingClient.path('/listings/search').get({
+      options: {
+        next: {
+          revalidate: 10,
+          tags: ['listings'],
+        },
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/search',
+      expect.objectContaining({ next: { revalidate: 10, tags: ['listings'] } }),
+    );
+  });
+
   it('applies a sanitizer', async () => {
     mockResolvedOnce({});
     const response = await listingClient

--- a/src/__tests__/post.test.ts
+++ b/src/__tests__/post.test.ts
@@ -13,6 +13,38 @@ describe('post', () => {
     );
   });
 
+  it('passes the cache options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient.path('/listings/create').post({
+      data: { make: 'bmw' },
+      options: {
+        cache: 'no-store',
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/create',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('passes the next options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient.path('/listings/create').post({
+      data: { make: 'bmw' },
+      options: {
+        next: {
+          revalidate: 10,
+          tags: ['listings'],
+        },
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/create',
+      expect.objectContaining({ next: { revalidate: 10, tags: ['listings'] } }),
+    );
+  });
+
   it('calls fetch with an empty body', async () => {
     mockResolvedOnce(null);
     await listingClient.path('/calculate').post({ data: null });

--- a/src/__tests__/put.test.ts
+++ b/src/__tests__/put.test.ts
@@ -15,6 +15,42 @@ describe('put', () => {
     );
   });
 
+  it('passes the cache options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient.path('/listings/{listingId}', { listingId: 123 }).put({
+      data: {
+        make: 'bmw',
+      },
+      options: {
+        cache: 'no-store',
+      },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/123',
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+
+  it('passes the next options to fetch', async () => {
+    mockResolvedOnce({ data: '12345' });
+    await listingClient.path('/listings/{listingId}', { listingId: 123 }).put({
+      data: {
+        make: 'bmw',
+      },
+      options: {
+        next: {
+          revalidate: 10,
+          tags: ['listings'],
+        },
+      },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/123',
+      expect.objectContaining({ next: { revalidate: 10, tags: ['listings'] } }),
+    );
+  });
+
   it('applies a sanitizer', async () => {
     mockResolvedOnce({});
     const response = await listingClient

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -50,6 +50,13 @@ export class FetchClient {
     };
   }
 
+  private getFetchOptions(options?: RequestOptions) {
+    return {
+      ...(options?.cache ? { cache: options.cache } : {}),
+      ...(options?.next ? { next: options.next } : {}),
+    };
+  }
+
   private static async buildResponseDataObject<
     ResponseData,
     RequestData extends object,
@@ -138,6 +145,7 @@ export class FetchClient {
       await fetch(this.getPath({ path, options, searchParams }), {
         method: 'GET',
         headers: this.getHeaders(options),
+        ...this.getFetchOptions(options),
       }),
       sanitizer,
     );
@@ -171,6 +179,7 @@ export class FetchClient {
         method: 'POST',
         headers,
         body,
+        ...this.getFetchOptions(options),
       }),
       sanitizer,
     );
@@ -193,6 +202,7 @@ export class FetchClient {
         method: 'PUT',
         headers: this.getHeaders(options),
         body: body && JSON.stringify(body),
+        ...this.getFetchOptions(options),
       }),
       sanitizer,
     );
@@ -213,6 +223,7 @@ export class FetchClient {
       await fetch(this.getPath({ path, options, searchParams }), {
         method: 'DELETE',
         headers: this.getHeaders(options),
+        ...this.getFetchOptions(options),
       }),
       sanitizer,
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ export interface RequestOptions {
   baseUrl?: string;
   headers?: Record<string, string>;
   accessToken?: string | null;
+  cache?: 'no-store' | 'force-cache';
+  next?: {
+    revalidate?: false | 0 | number;
+    tags?: string[];
+  };
 }
 
 function StronglyTypedClient<Configuration extends ClientConfiguration>(


### PR DESCRIPTION
## Motivation and context

Nextjs [extends the web `fetch` API](https://nextjs.org/docs/app/api-reference/functions/fetch) with some custom parameters for caching and revalidation. This PR allows passing `cache` and `next` via `RequestOptions` to customise the caching behaviour.

## Before

```
await listingClient.path('/listings/search').get({
  options: {
    cache: 'force-cache',
    next: {
      revalidate: 10,
      tags: ['listings'],
    },
  },
});
```

would yield a type error

## After

```
await listingClient.path('/listings/search').get({
  options: {
    cache: 'force-cache',
    next: {
      revalidate: 10,
      tags: ['listings'],
    },
  },
});
```

passes through `cache` and `next` options to the `fetch` call, allowing us to leverage the fetch extensions from the nextjs team.
