### PR TITLE
feat: support streaming for post requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ if (response.ok) {
 }
 ```
 
+### Streaming responses
+
+For endpoints that return a readable response body, such as server-sent events over a `POST` request, use `postStream`.
+It keeps the same path parameters, request body, search params, headers, and authorization handling as `post`, but returns
+the `ReadableStream<Uint8Array>` without consuming it.
+
+```typescript
+interface ChatClientConfiguration extends ClientConfiguration {
+  'conversations/{conversationId}/messages': {
+    postStream: (
+      request: RequestType<{ text: string }>
+    ) => StreamResponseType<{ text: string }>;
+  };
+}
+
+const response = await chatClient
+  .path('conversations/{conversationId}/messages', { conversationId })
+  .postStream({ data: { text: 'Hello' }, options: { signal } });
+
+if (response.ok) {
+  const reader = response.body.getReader();
+}
+```
+
 ### Testing
 
 Create a file in the `__mocks__` directory called `@smg-automotive/api-client-pkg.ts` with the following content:

--- a/__mocks__/index.ts
+++ b/__mocks__/index.ts
@@ -6,6 +6,13 @@ export const ApiClient = () => ({
     post: jest
       .fn()
       .mockReturnValue(Promise.resolve({ status: 201, body: {}, ok: true })),
+    postStream: jest.fn().mockReturnValue(
+      Promise.resolve({
+        status: 201,
+        body: new ReadableStream<Uint8Array>(),
+        ok: true,
+      }),
+    ),
     put: jest
       .fn()
       .mockReturnValue(Promise.resolve({ status: 204, body: {}, ok: true })),

--- a/jest/helpers/fetch.ts
+++ b/jest/helpers/fetch.ts
@@ -12,6 +12,29 @@ export const mockResolvedOnce = (value: unknown) => {
   );
 };
 
+export const mockResolvedStreamOnce = (
+  value: ReadableStream<Uint8Array> = new ReadableStream<Uint8Array>(),
+) => {
+  fetchMock.mockReturnValueOnce(
+    Promise.resolve({
+      status: 200,
+      ok: true,
+      body: value,
+    }),
+  );
+};
+
+export const mockMissingStreamBodyOnce = () => {
+  fetchMock.mockReturnValueOnce(
+    Promise.resolve({
+      status: 200,
+      ok: true,
+      body: null,
+      url: 'https://api.automotive.ch/api/listings/create-stream',
+    }),
+  );
+};
+
 export const mockFetchFailOnce = () => {
   fetchMock.mockReturnValueOnce(Promise.reject(new Error()));
 };

--- a/jest/helpers/listingClient.ts
+++ b/jest/helpers/listingClient.ts
@@ -3,6 +3,7 @@ import {
   ClientConfiguration,
   RequestType,
   ResponseType,
+  StreamResponseType,
 } from '@/src';
 
 export type Listing = {
@@ -35,6 +36,11 @@ export interface ListingClientConfiguration extends ClientConfiguration {
   };
   '/listings/create': {
     post: (data: RequestType<Listing>) => ResponseType<Listing>;
+  };
+  '/listings/create-stream': {
+    postStream: (
+      data: RequestType<Listing, DummySearchParams>,
+    ) => StreamResponseType<Listing>;
   };
   '/calculate': {
     post: (data: RequestType<null>) => ResponseType<Listing>;

--- a/src/__tests__/postStream.test.ts
+++ b/src/__tests__/postStream.test.ts
@@ -1,0 +1,87 @@
+import { listingClient } from '@/jest/helpers/listingClient';
+import {
+  mockApiFailOnce,
+  mockMissingStreamBodyOnce,
+  mockResolvedStreamOnce,
+} from '@/jest/helpers/fetch';
+
+describe('postStream', () => {
+  it('calls fetch with POST and returns the readable stream', async () => {
+    const stream = new ReadableStream<Uint8Array>();
+
+    mockResolvedStreamOnce(stream);
+
+    const response = await listingClient
+      .path('/listings/create-stream')
+      .postStream({ data: { make: 'bmw' } });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/create-stream',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ make: 'bmw' }),
+      }),
+    );
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.body).toBe(stream);
+    }
+  });
+
+  it('passes the signal to fetch', async () => {
+    const controller = new AbortController();
+
+    mockResolvedStreamOnce();
+
+    await listingClient.path('/listings/create-stream').postStream({
+      data: { make: 'bmw' },
+      options: { signal: controller.signal },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/create-stream',
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('adds searchParams on method POST stream', async () => {
+    mockResolvedStreamOnce();
+
+    await listingClient.path('/listings/create-stream').postStream({
+      data: { make: 'bmw' },
+      searchParams: { test: 'hereIAm' },
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.automotive.ch/api/listings/create-stream?test=hereIAm',
+      expect.any(Object),
+    );
+  });
+
+  it('returns the parsed API error response', async () => {
+    mockApiFailOnce();
+
+    const response = await listingClient
+      .path('/listings/create-stream')
+      .postStream({ data: { make: 'bmw' } });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.body.message).toBe('Wrong data format');
+    }
+  });
+
+  it('returns an error when the stream body is missing', async () => {
+    mockMissingStreamBodyOnce();
+
+    const response = await listingClient
+      .path('/listings/create-stream')
+      .postStream({ data: { make: 'bmw' } });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.body.code).toBe('STREAM_RESPONSE_BODY_MISSING');
+    }
+  });
+});

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ResponseType } from './responseType';
+import { ResponseType, StreamResponseType } from './responseType';
 
 import { RequestOptions } from './index';
 
@@ -13,6 +13,7 @@ export type RequestType<DataType = never, SearchParamsType = never> = {
 type Methods = {
   get?: (request: RequestType) => ResponseType<never, any>;
   post?: (request: RequestType<any>) => ResponseType<any, any>;
+  postStream?: (request: RequestType<any>) => StreamResponseType<any>;
   put?: (request: RequestType<any>) => ResponseType<any, any>;
   delete?: (request: RequestType) => ResponseType<never, any>;
 };

--- a/src/fetchClient.ts
+++ b/src/fetchClient.ts
@@ -1,5 +1,10 @@
 import { DataSanitizer } from './sanitizers';
-import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
+import {
+  ErrorResponse,
+  ResponseType,
+  StreamResponseType,
+  SuccessResponse,
+} from './responseType';
 
 import { FetchClientConfiguration, RequestOptions } from './index';
 
@@ -54,6 +59,7 @@ export class FetchClient {
     return {
       ...(options?.cache ? { cache: options.cache } : {}),
       ...(options?.next ? { next: options.next } : {}),
+      ...(options?.signal ? { signal: options.signal } : {}),
     };
   }
 
@@ -183,6 +189,76 @@ export class FetchClient {
       }),
       sanitizer,
     );
+  };
+
+  postStream = async <RequestData extends object>({
+    path,
+    body: originalBody,
+    options,
+    searchParams,
+  }: {
+    path: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    body: any;
+    options?: RequestOptions;
+    searchParams?: Record<string, string>;
+  }): StreamResponseType<RequestData> => {
+    const headers = this.getHeaders(options);
+    let body = originalBody && JSON.stringify(originalBody);
+
+    // Form data needs to be plain with no content type set
+    if (originalBody instanceof FormData) {
+      delete headers['Content-Type'];
+      body = originalBody;
+    }
+
+    const response = await fetch(
+      this.getPath({ path, options, searchParams }),
+      {
+        method: 'POST',
+        headers,
+        body,
+        ...FetchClient.getFetchOptions(options),
+      },
+    );
+
+    if (!response.ok) {
+      return FetchClient.returnData<never, RequestData>(response);
+    }
+
+    const {
+      headers: responseHeaders,
+      redirected,
+      status,
+      statusText,
+      type,
+      url,
+    } = response;
+    const baseResponse = {
+      headers: responseHeaders,
+      redirected,
+      status,
+      statusText,
+      type,
+      url,
+    };
+
+    if (!response.body) {
+      return {
+        ok: false,
+        body: {
+          code: 'STREAM_RESPONSE_BODY_MISSING',
+          message: `No stream response body returned from ${response.url}`,
+        },
+        ...baseResponse,
+      };
+    }
+
+    return {
+      ok: true,
+      body: response.body,
+      ...baseResponse,
+    };
   };
 
   put = async <T>({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { SortedQuery, SortOrderParams, SortParams, SortQuery } from './sort';
 import { Sanitizers } from './sanitizers';
-import { ErrorResponse, ResponseType, SuccessResponse } from './responseType';
+import {
+  ErrorResponse,
+  ResponseType,
+  StreamResponseType,
+  StreamSuccessResponse,
+  SuccessResponse,
+} from './responseType';
 import { replaceParameters } from './pathParameters';
 import { Path } from './path';
 import {
@@ -33,6 +39,7 @@ export interface RequestOptions {
   baseUrl?: string;
   headers?: Record<string, string>;
   accessToken?: string | null;
+  signal?: AbortSignal;
   cache?: 'no-store' | 'force-cache';
   next?: {
     revalidate?: false | 0 | number;
@@ -73,6 +80,19 @@ function StronglyTypedClient<Configuration extends ClientConfiguration>(
             sanitizer: pathSanitizers?.post,
           });
         },
+        postStream: (
+          { data, options, searchParams } = {
+            data: {},
+            options: {},
+          },
+        ) => {
+          return fetchClient.postStream({
+            path: replacedPath,
+            body: data,
+            options,
+            searchParams,
+          });
+        },
         put: ({ data, options } = { data: {}, options: {} }) => {
           return fetchClient.put({
             path: replacedPath,
@@ -98,6 +118,8 @@ export {
   StronglyTypedClient as ApiClient,
   ClientConfiguration,
   ResponseType,
+  StreamResponseType,
+  StreamSuccessResponse,
   RequestType,
   SuccessResponse,
   ErrorResponse,

--- a/src/responseType.ts
+++ b/src/responseType.ts
@@ -31,6 +31,11 @@ export interface SuccessResponse<Body> extends LeanResponse {
   body: Body;
 }
 
+export interface StreamSuccessResponse extends LeanResponse {
+  ok: true;
+  body: ReadableStream<Uint8Array>;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UnwrapResponseUnion<T extends Awaited<ResponseType<any, any>>> =
   T extends SuccessResponse<infer Body> ? Body : never;
@@ -43,3 +48,7 @@ export type ResponseType<
   RequestData extends object = object,
   Body = never,
 > = Promise<ErrorResponse<RequestData> | SuccessResponse<Body>>;
+
+export type StreamResponseType<RequestData extends object = object> = Promise<
+  ErrorResponse<RequestData> | StreamSuccessResponse
+>;


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-5355

## Motivation and context

Extends the api client to support streaming on post requests. It is needed for conversational search.

Related PR: https://github.com/smg-automotive/listings-web/pull/4418
